### PR TITLE
Enable player names, colors, and networked spells

### DIFF
--- a/public/collisions.js
+++ b/public/collisions.js
@@ -24,6 +24,38 @@ function checkCollisions() {
     }
   }
 
+  // Our spells hitting other players
+  for (const id in players) {
+    const other = players[id];
+    for (let i = wizard.spells.length - 1; i >= 0; i--) {
+      const spell = wizard.spells[i];
+      const dx = spell.x - other.x;
+      const dy = spell.y - other.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist < spell.radius + 20) {
+        wizard.spells.splice(i, 1);
+        socket.emit('playerHit', id);
+        break;
+      }
+    }
+  }
+
+  // Spells from others hitting us
+  for (const id in players) {
+    const other = players[id];
+    for (let i = other.spells.length - 1; i >= 0; i--) {
+      const spell = other.spells[i];
+      const dx = spell.x - wizard.x;
+      const dy = spell.y - wizard.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist < spell.radius + wizard.radius) {
+        other.spells.splice(i, 1);
+        if (wizard.hp > 0) wizard.hp--;
+        break;
+      }
+    }
+  }
+
   // Damage from touching shapes
   for (let shape of shapes) {
     const dx = wizard.x - shape.x;

--- a/public/menu.js
+++ b/public/menu.js
@@ -10,5 +10,7 @@ document.getElementById("startButton").addEventListener("click", () => {
     wizard.name = name;
     wizard.color = color;
 
+    socket.emit('playerInfo', { name, color });
+
     document.getElementById("menu").style.display = "none";
 });

--- a/public/wizard.js
+++ b/public/wizard.js
@@ -26,5 +26,15 @@ window.shootSpell = function () {
     radius: 5,
     color: "cyan"
   });
+  if (typeof socket !== 'undefined') {
+    socket.emit('shootSpell', {
+      x: wizard.x,
+      y: wizard.y,
+      angle: wizard.angle,
+      speed: 6,
+      radius: 5,
+      color: 'cyan'
+    });
+  }
 };
 


### PR DESCRIPTION
## Summary
- add playerInfo event and broadcast updates
- send spells between players and handle taking damage
- update client to spawn and draw other players' bullets
- display player names and colors

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_684709621adc832ca49337fff06fafba