### PR TITLE
Improve gameplay controls and UI

### DIFF
--- a/public/collisions.js
+++ b/public/collisions.js
@@ -1,4 +1,5 @@
 function checkCollisions() {
+  if (!window.gameStarted) return;
   for (let i = wizard.spells.length - 1; i >= 0; i--) {
     const spell = wizard.spells[i];
     for (let j = shapes.length - 1; j >= 0; j--) {
@@ -50,7 +51,10 @@ function checkCollisions() {
       const dist = Math.sqrt(dx * dx + dy * dy);
       if (dist < spell.radius + wizard.radius) {
         other.spells.splice(i, 1);
-        if (wizard.hp > 0) wizard.hp--;
+        if (wizard.invincibility <= 0 && wizard.hp > 0) {
+          wizard.hp--;
+          wizard.invincibility = 60;
+        }
         break;
       }
     }
@@ -62,7 +66,10 @@ function checkCollisions() {
     const dy = wizard.y - shape.y;
     const dist = Math.sqrt(dx * dx + dy * dy);
     if (dist < wizard.radius + shape.radius) {
-      if (wizard.hp > 0) wizard.hp--;
+      if (wizard.invincibility <= 0 && wizard.hp > 0) {
+        wizard.hp--;
+        wizard.invincibility = 60;
+      }
       break;
     }
   }

--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
     <button id="startButton">Play</button>
   </div>
 
-  <canvas id="gameCanvas"></canvas>
+  <canvas id="gameCanvas" class="blurred"></canvas>
   <div id="chat">
     <div id="chatMessages"></div>
     <input id="chatInput" type="text" placeholder="Type a message...">

--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,6 @@
 const socket = io();
 const players = {};
+window.gameStarted = false;
 
 socket.on('chatMessage', data => {
   if (data.id === socket.id) return;
@@ -72,6 +73,7 @@ let lastShotTime = 0;
 const shootCooldown = 200;
 
 function moveWizard() {
+  if (!window.gameStarted) return;
   if (window.keys["w"] || window.keys["ArrowUp"]) wizard.y -= wizard.speed;
   if (window.keys["s"] || window.keys["ArrowDown"]) wizard.y += wizard.speed;
   if (window.keys["a"] || window.keys["ArrowLeft"]) wizard.x -= wizard.speed;
@@ -91,6 +93,7 @@ function moveWizard() {
 }
 
 function updateSpells() {
+  if (!window.gameStarted) return;
   wizard.spells.forEach(spell => {
     spell.x += Math.cos(spell.angle) * spell.speed;
     spell.y += Math.sin(spell.angle) * spell.speed;
@@ -125,9 +128,11 @@ function drawChatBubble(player) {
   ctx.font = "14px Arial";
   ctx.fillStyle = "white";
 
-  const textX = player.x - maxWidth / 2 - cameraX;
+  ctx.textAlign = "center";
+  const textX = player.x - cameraX;
   const textY = player.y - player.radius - 20 - cameraY;
   drawWrappedText(player.chatBubble, textX, textY, maxWidth, lineHeight);
+  ctx.textAlign = "start";
 
   if (player.chatTimer === 0) player.chatBubble = "";
 }
@@ -145,6 +150,7 @@ function gameLoop(timestamp) {
   updateSpells();
   checkCollisions();
   updateChatBubble();
+  if (wizard.invincibility > 0) wizard.invincibility--;
 
   drawShape(wizard);
   drawChatBubble(wizard);

--- a/public/menu.js
+++ b/public/menu.js
@@ -1,6 +1,16 @@
-document.getElementById("startButton").addEventListener("click", () => {
+const startButton = document.getElementById("startButton");
+const colorInput = document.getElementById("colorInput");
+
+// preview color on the color input/button itself
+function updateColorPreview() {
+    colorInput.style.backgroundColor = colorInput.value;
+}
+colorInput.addEventListener("input", updateColorPreview);
+updateColorPreview();
+
+startButton.addEventListener("click", () => {
     const name = document.getElementById("nameInput").value.trim();
-    const color = document.getElementById("colorInput").value;
+    const color = colorInput.value;
 
     if (name === "") {
         alert("Please enter your name.");
@@ -13,4 +23,6 @@ document.getElementById("startButton").addEventListener("click", () => {
     socket.emit('playerInfo', { name, color });
 
     document.getElementById("menu").style.display = "none";
+    document.getElementById("gameCanvas").classList.remove("blurred");
+    window.gameStarted = true;
 });

--- a/public/styles.css
+++ b/public/styles.css
@@ -10,6 +10,11 @@ body {
 canvas {
   display: block;
   background-color: #2c2f33;
+  transition: filter 0.3s ease;
+}
+
+.blurred {
+  filter: blur(5px);
 }
 
 #menu {

--- a/public/ui.js
+++ b/public/ui.js
@@ -81,14 +81,14 @@ function drawWrappedText(text, x, y, maxWidth, lineHeight) {
     const metrics = ctx.measureText(testLine);
     const testWidth = metrics.width;
     if (testWidth > maxWidth && n > 0) {
-      ctx.fillText(line, x, yy);
+      ctx.fillText(line.trim(), x, yy);
       line = words[n] + " ";
       yy += lineHeight;
     } else {
       line = testLine;
     }
   }
-  ctx.fillText(line, x, yy);
+  ctx.fillText(line.trim(), x, yy);
 }
 
 function drawUI() {
@@ -96,9 +96,9 @@ function drawUI() {
 
   ctx.fillStyle = "white";
   ctx.font = "16px Arial";
-  ctx.fillText("XP: " + wizard.xp + " / " + (wizard.level * 20), 10, 20);
-  ctx.fillText("Level: " + wizard.level, 10, 40);
-  ctx.fillText("HP: " + wizard.hp + " / " + wizard.maxHp, 10, 60);
+  ctx.fillText("XP: " + wizard.xp + " / " + (wizard.level * 20), 20, 30);
+  ctx.fillText("Level: " + wizard.level, 20, 50);
+  ctx.fillText("HP: " + wizard.hp + " / " + wizard.maxHp, 20, 70);
 
   if (wizard.levelMessage) {
     ctx.font = "30px Arial";
@@ -111,9 +111,11 @@ function drawUI() {
     ctx.fillStyle = "white";
     const maxWidth = 200;
     const lineHeight = 16;
-    const textX = wizard.x - maxWidth / 2 - cameraX;
+    ctx.textAlign = "center";
+    const textX = wizard.x - cameraX;
     const textY = wizard.y - wizard.radius - 20 - cameraY;
     drawWrappedText(wizard.chatBubble, textX, textY, maxWidth, lineHeight);
+    ctx.textAlign = "start";
   }
 }
 

--- a/public/wizard.js
+++ b/public/wizard.js
@@ -13,10 +13,12 @@ const wizard = {
   maxHp: 10,
   levelMessage: "",
   chatBubble: "",
-  chatTimer: 0
+  chatTimer: 0,
+  invincibility: 0
 };
 
 window.shootSpell = function () {
+  if (!window.gameStarted) return;
   console.log("Spell shot");
   wizard.spells.push({
     x: wizard.x,


### PR DESCRIPTION
## Summary
- show selected wizard color in menu and blur background
- require Play button to start the game and disable actions until then
- center chat bubbles above each player
- add brief invincibility when taking damage
- move HP/XP text fully on screen

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68471bb78f20832c9c90ff5adb0ee239